### PR TITLE
Changed event handlers to accept generic events to prevent casting error...

### DIFF
--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -16,150 +16,151 @@
  */
 package org.openvv {
 
-    import flash.display.Sprite;
-    import flash.display.Stage;
-    import flash.display.StageDisplayState;
-    import flash.events.Event;
-    import flash.events.EventDispatcher;
-    import flash.events.TimerEvent;
-    import flash.external.ExternalInterface;
-    import flash.utils.Timer;
-    	
-    import org.openvv.events.OVVEvent;
+	import flash.display.Sprite;
+	import flash.display.Stage;
+	import flash.display.StageDisplayState;
+	import flash.events.Event;
+	import flash.events.EventDispatcher;
+	import flash.events.TimerEvent;
+	import flash.external.ExternalInterface;
+	import flash.utils.Timer;
+	
 	import net.iab.VPAIDEvent;
+	
+	import org.openvv.events.OVVEvent;
 
-    /**
-     * The event dispatched when the asset has been viewable for 5 contiguous seconds
-     */
-    [Event(name = "OVVImpression", type = "org.openvv.events.OVVEvent")]
-    /**
-     * The Event dispatched when OVV emits information messages
-     */
-    [Event(name = "OVVLog", type = "org.openvv.events.OVVEvent")]
-    /**
-     * The event dispatched when OVV encounters an error
-     */
-    [Event(name = "OVVError", type = "org.openvv.events.OVVEvent")]
-    /**
-     * <p>
-     * OVVAsset is the entry point into OVV. To use OVVV, create an instance of
-     * this object and pass in the URL of a publicly available OVVBeacon.swf.
-     * </p><p>
-     * OVV will then attempt to determine the viewability of the SWF it's
-     * compiled into using one of two techniques:
-     * </p>
-     * <ol>
-     * <li>
-     * The "geometry technique" uses JavaScript APIs such as
-     * document.body.clientWidth/Height and getClientRects() to determine
-     * how much of the SWF is within the viewport of the browser. It then sets
-     * OVVCheck.viewabilityState to OVVCheck.VIEWABLE or OVVCheck.UNVIEWABLE.
-     * </li>
-     * <li>
-     * When the asset determines that it is being viewed within an iframe,
-     * it will then attempt to use the "beacon technique." This technique places
-     * beacon SWFs on top of the asset and leverages the ThrottleEvent
-     * introduced in FlashPlayer 11 to determine whether each beacon is within
-     * the browser's viewport. If the Flash Player or the browser being used
-     * don't support ThrottleEvent, OVVCheck.viewabilityState will be set to
-     * OVVCheck.UNMEASURABLE.
-     * </li>
-     * </ol>
-     * <p>
-     * When OVV.DEBUG (in JavaScript) is set to true, OVV will enlarge and
-     * display the beacons on the page and use both techniques. OVV will then
-     * also populate the OVVCheck.beaconViewabilityState and
-     * OVVCheck.geometryViewabilityState properties so that the end user can
-     * compare the results of each techniques.
-     * </p>
-     */
-    public class OVVAsset extends EventDispatcher {
+	/**
+	 * The event dispatched when the asset has been viewable for 5 contiguous seconds
+	 */
+	[Event(name = "OVVImpression", type = "org.openvv.events.OVVEvent")]
+	/**
+	 * The Event dispatched when OVV emits information messages
+	 */
+	[Event(name = "OVVLog", type = "org.openvv.events.OVVEvent")]
+	/**
+	 * The event dispatched when OVV encounters an error
+	 */
+	[Event(name = "OVVError", type = "org.openvv.events.OVVEvent")]
+	/**
+	 * <p>
+	 * OVVAsset is the entry point into OVV. To use OVVV, create an instance of
+	 * this object and pass in the URL of a publicly available OVVBeacon.swf.
+	 * </p><p>
+	 * OVV will then attempt to determine the viewability of the SWF it's
+	 * compiled into using one of two techniques:
+	 * </p>
+	 * <ol>
+	 * <li>
+	 * The "geometry technique" uses JavaScript APIs such as
+	 * document.body.clientWidth/Height and getClientRects() to determine
+	 * how much of the SWF is within the viewport of the browser. It then sets
+	 * OVVCheck.viewabilityState to OVVCheck.VIEWABLE or OVVCheck.UNVIEWABLE.
+	 * </li>
+	 * <li>
+	 * When the asset determines that it is being viewed within an iframe,
+	 * it will then attempt to use the "beacon technique." This technique places
+	 * beacon SWFs on top of the asset and leverages the ThrottleEvent
+	 * introduced in FlashPlayer 11 to determine whether each beacon is within
+	 * the browser's viewport. If the Flash Player or the browser being used
+	 * don't support ThrottleEvent, OVVCheck.viewabilityState will be set to
+	 * OVVCheck.UNMEASURABLE.
+	 * </li>
+	 * </ol>
+	 * <p>
+	 * When OVV.DEBUG (in JavaScript) is set to true, OVV will enlarge and
+	 * display the beacons on the page and use both techniques. OVV will then
+	 * also populate the OVVCheck.beaconViewabilityState and
+	 * OVVCheck.geometryViewabilityState properties so that the end user can
+	 * compare the results of each techniques.
+	 * </p>
+	 */
+	public class OVVAsset extends EventDispatcher {
 
-        ////////////////////////////////////////////////////////////
-        //EMBEDS 
-        ////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////
+		//EMBEDS 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * The JavaScript source code
-         */
-        [Embed(source = "js/OVVAsset.js", mimeType = "application/octet-stream")]
-        public static const OVVAssetJSSource: Class;
+		/**
+		 * The JavaScript source code
+		 */
+		[Embed(source = "js/OVVAsset.js", mimeType = "application/octet-stream")]
+		public static const OVVAssetJSSource: Class;
 
-        ////////////////////////////////////////////////////////////
-        //   CONSTANTS 
-        ////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////
+		//   CONSTANTS 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * The number of consecutive intervals of viewability required before
-         * the VIEWABLE_IMPRESSION event will be fired (2 seconds)
-         */
-        public static const VIEWABLE_IMPRESSION_THRESHOLD: Number = 10;				
-        
-        /**
-         * The number of milliseconds between polling JavaScript for
-         * viewability information
-         */
-        public static const POLL_INTERVAL:int = 200;
+		/**
+		 * The number of consecutive intervals of viewability required before
+		 * the VIEWABLE_IMPRESSION event will be fired (2 seconds)
+		 */
+		public static const VIEWABLE_IMPRESSION_THRESHOLD: Number = 10;				
 
-        /**
-         * Hold OVV version. Will past to JavaScript as well $ovv.version
-         */
-        public static const VERSION: Number = 1;
-        
+		/**
+		 * The number of milliseconds between polling JavaScript for
+		 * viewability information
+		 */
+		public static const POLL_INTERVAL:int = 200;
 
-        ////////////////////////////////////////////////////////////
-        //   ATTRIBUTES 
-        ////////////////////////////////////////////////////////////
+		/**
+		 * Hold OVV version. Will past to JavaScript as well $ovv.version
+		 */
+		public static const VERSION: Number = 1;
 
-        /**
-         * Whether the asset has dispatched the DISCERNABLE_IMPRESSION event
-         */
-        private var _hasDispatchedDImp: Boolean = false;
 
-        /**
-         * The randomly generated unique identifier of this asset
-         */
-        private var _id: String;
+		////////////////////////////////////////////////////////////
+		//   ATTRIBUTES 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * The timer used to measure intervals
-         */
-        private var _intervalTimer: Timer;
+		/**
+		 * Whether the asset has dispatched the DISCERNABLE_IMPRESSION event
+		 */
+		private var _hasDispatchedDImp: Boolean = false;
 
-        /**
-         * The number of consecutive intervals in which the asset has been
-         * viewable. Reset to 0 when the asset is found to be unviewable.
-         */
-        private var _intervalsInView: Number;
+		/**
+		 * The randomly generated unique identifier of this asset
+		 */
+		private var _id: String;
 
-        /**
-         * The RenderMeter which gauges the frame rate of the asset
-         */
-        private var _renderMeter: OVVRenderMeter;
+		/**
+		 * The timer used to measure intervals
+		 */
+		private var _intervalTimer: Timer;
 
-        /**
-         * A Sprite used for measuring frame rate and receiving ThrottlEvents
-         */
-        private var _sprite: Sprite;
+		/**
+		 * The number of consecutive intervals in which the asset has been
+		 * viewable. Reset to 0 when the asset is found to be unviewable.
+		 */
+		private var _intervalsInView: Number;
 
-        /**
-         * A reference to the stage. Used for detecting full screen viewing.
-         */
-        private var _stage:Stage;
+		/**
+		 * The RenderMeter which gauges the frame rate of the asset
+		 */
+		private var _renderMeter: OVVRenderMeter;
 
-        /**
-         * The last recorded ThrottleState
-         *
-         * @see org.openvv.OVVThrottleType
-         * @see http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/events/ThrottleEvent.html
-         */
-        private var _throttleState: String;		
-		
+		/**
+		 * A Sprite used for measuring frame rate and receiving ThrottlEvents
+		 */
+		private var _sprite: Sprite;
+
+		/**
+		 * A reference to the stage. Used for detecting full screen viewing.
+		 */
+		private var _stage:Stage;
+
+		/**
+		 * The last recorded ThrottleState
+		 *
+		 * @see org.openvv.OVVThrottleType
+		 * @see http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/events/ThrottleEvent.html
+		 */
+		private var _throttleState: String;		
+
 		/**
 		 * Indicate whether the Impression event was raised
 		 */
 		private var _impressionEventRaised: Boolean = false;
-		
+
 		/**
 		 * A array of all VPAID events
 		 */
@@ -168,87 +169,87 @@ package org.openvv {
 			VPAIDEvent.AdStarted,VPAIDEvent.AdStopped, VPAIDEvent.AdUserAcceptInvitation,  VPAIDEvent.AdUserClose, VPAIDEvent.AdUserMinimize, VPAIDEvent.AdVideoComplete, 
 			VPAIDEvent.AdVideoFirstQuartile, VPAIDEvent.AdVideoMidpoint, VPAIDEvent.AdVideoThirdQuartile, VPAIDEvent.AdVolumeChange, VPAIDEvent.AdSkipped,
 			VPAIDEvent.AdSkippableStateChange, VPAIDEvent.AdSizeChange, VPAIDEvent.AdDurationChange, VPAIDEvent.AdInteraction]);
-	
+
 		/**
 		 * A vector of all OVV events
 		 */
 		private static const OVV_EVENTS:Array = ([OVVEvent.OVVError,OVVEvent.OVVLog, OVVEvent.OVVImpression]);	
-	
+
 		private var _vpaidEventsDispatcher:EventDispatcher = null;
 
-        ////////////////////////////////////////////////////////////
-        //   CONSTRUCTOR 
-        ////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////
+		//   CONSTRUCTOR 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * Generates a random ID for this asset. Creates JavaScript
-         * callbacks, starts the RenderMeter and sets up ThrottleEvent
-         * listeners, and initializes the JavaScript portion of OpenVV.
-         *
-         * @param beaconSwfUrl The fully qualified URL of OVVBeacon.swf for
-         * OpenVV to use. For example, "http://localhost/OVVBeacon.swf". If
-         * not supplied, the "beacon" method for detecting viewability will
-         * be unavailable.
-         * @param id The unique identifier of this OVVAsset. If not supplied,
-         * it will be randomly generated.
-         * @param interval The number of milliseconds between polls to
-         * JavaScript for viewability information. Defaults to 250.
-         */
-        public function OVVAsset(beaconSwfUrl:String = null, id:String = null, stage:Stage=null) {
-            
-            if (!externalInterfaceIsAvailable()) {
-                dispatchEvent(new OVVEvent(OVVEvent.OVVError, {
-                    "message": "ExternalInterface unavailable"
-                }));
-                return;
-            }
+		/**
+		 * Generates a random ID for this asset. Creates JavaScript
+		 * callbacks, starts the RenderMeter and sets up ThrottleEvent
+		 * listeners, and initializes the JavaScript portion of OpenVV.
+		 *
+		 * @param beaconSwfUrl The fully qualified URL of OVVBeacon.swf for
+		 * OpenVV to use. For example, "http://localhost/OVVBeacon.swf". If
+		 * not supplied, the "beacon" method for detecting viewability will
+		 * be unavailable.
+		 * @param id The unique identifier of this OVVAsset. If not supplied,
+		 * it will be randomly generated.
+		 * @param interval The number of milliseconds between polls to
+		 * JavaScript for viewability information. Defaults to 250.
+		 */
+		public function OVVAsset(beaconSwfUrl:String = null, id:String = null, stage:Stage=null) {
 
-            _id = (id !== null) ? id : "ovv" + Math.floor(Math.random() * 1000000000).toString();
-            _stage = stage;
+			if (!externalInterfaceIsAvailable()) {
+				dispatchEvent(new OVVEvent(OVVEvent.OVVError, {
+						"message": "ExternalInterface unavailable"
+					}));
+				return;
+			}
 
-            ExternalInterface.addCallback(_id, flashProbe);
-            ExternalInterface.addCallback("startImpressionTimer", startImpressionTimer);
+			_id = (id !== null) ? id : "ovv" + Math.floor(Math.random() * 1000000000).toString();
+			_stage = stage;
 
-            _sprite = new Sprite();
-            _renderMeter = new OVVRenderMeter(_sprite);
-            _sprite.addEventListener(OVVThrottleType.THROTTLE, onThrottleEvent);
+			ExternalInterface.addCallback(_id, flashProbe);
+			ExternalInterface.addCallback("startImpressionTimer", startImpressionTimer);
 
-            var ovvAssetSource: String = new OVVAssetJSSource().toString();
-            ovvAssetSource = ovvAssetSource
-                                .replace(/OVVID/g, _id)
-                                .replace(/INTERVAL/g, POLL_INTERVAL)
-                                .replace(/VERSION/g, VERSION);
-			
+			_sprite = new Sprite();
+			_renderMeter = new OVVRenderMeter(_sprite);
+			_sprite.addEventListener(OVVThrottleType.THROTTLE, onThrottleEvent);
+
+			var ovvAssetSource: String = new OVVAssetJSSource().toString();
+			ovvAssetSource = ovvAssetSource
+				.replace(/OVVID/g, _id)
+				.replace(/INTERVAL/g, POLL_INTERVAL)
+				.replace(/VERSION/g, VERSION);
+
 			if (beaconSwfUrl)
 			{
 				ovvAssetSource = ovvAssetSource.replace(/BEACON_SWF_URL/g, beaconSwfUrl);
 			}			            
-            ExternalInterface.call("eval", ovvAssetSource);
-        }
+			ExternalInterface.call("eval", ovvAssetSource);
+		}
 
-        ////////////////////////////////////////////////////////////
-        //   CLASS METHODS 
-        ////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////
+		//   CLASS METHODS 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * @return A Boolean indicating whether JavaScript is available within
-         * this container
-         */
-        public static function externalInterfaceIsAvailable(): Boolean {
-            var isEIAvailable: Boolean = false;
-
-            try {
-                isEIAvailable = !! ExternalInterface.call("function() { return 1; }");
-            } catch (e: SecurityError) {
-                // ignore
-            }
-
-            return isEIAvailable;
-        }
-		
 		/**
-		 * Register to the vpaidEventsDispatcher VPAID's events and allows 3rd parties to more easily provide video viewability measurement 
-		 * by exposing the VPAID data as well as the viewability data via a JavaScript API. 		 
+		 * @return A Boolean indicating whether JavaScript is available within
+		 * this container
+		 */
+		public static function externalInterfaceIsAvailable(): Boolean {
+			var isEIAvailable: Boolean = false;
+
+			try {
+				isEIAvailable = !! ExternalInterface.call("function() { return 1; }");
+			} catch (e: SecurityError) {
+				// ignore
+			}
+
+			return isEIAvailable;
+		}
+
+		/**
+		 * Register to the vpaidEventsDispatcher VPAID's events and allows 3rd parties to more easily provide video viewability measurement
+		 * by exposing the VPAID data as well as the viewability data via a JavaScript API.
 		 * @param	vpaidEventsDispatcher object that exposes VPAID events
 		 */
 		public function initEventsWiring(vpaidEventsDispatcher:EventDispatcher): void {	
@@ -257,7 +258,7 @@ package org.openvv {
 			registerEventHandler(vpaidEventsDispatcher);
 			_vpaidEventsDispatcher = vpaidEventsDispatcher;
 		}
-		
+
 		/**
 		 * Add a JavaScript resource upon reciveing a given vpaidEvent
 		 * @param	vpaidEvent The name of the VPAID event to add the JavaScript resource upon recived
@@ -268,202 +269,202 @@ package org.openvv {
 				throw "initEventsWiring must be called first.";
 			_vpaidEventsDispatcher.addEventListener(vpaidEvent, onInjectJavaScriptResource(tagUrl));
 		}
-		
-        ////////////////////////////////////////////////////////////
-        //   PUBLIC API 
-        ////////////////////////////////////////////////////////////
 
-        /**
-         * Returns an OVVCheck object which contains information about the
-         * current viewability state of the asset.
-         *
-         * @return OVVCheck An object containing all the properties OVV was
-         * able to gather from the container
-         *
-         * @see org.openvv.OVVCheck
-         */
-        public function checkViewability(): OVVCheck {
-            if (!externalInterfaceIsAvailable()) {
-                return new OVVCheck({
-                    "error": "ExternalInterface unavailable"
-                });
-            }
+		////////////////////////////////////////////////////////////
+		//   PUBLIC API 
+		////////////////////////////////////////////////////////////
 
-            var jsResults: Object = ExternalInterface.call("$ovv.getAssetById('" + _id + "')" + ".checkViewability");
-            var results: OVVCheck = new OVVCheck(jsResults);
-			
+		/**
+		 * Returns an OVVCheck object which contains information about the
+		 * current viewability state of the asset.
+		 *
+		 * @return OVVCheck An object containing all the properties OVV was
+		 * able to gather from the container
+		 *
+		 * @see org.openvv.OVVCheck
+		 */
+		public function checkViewability(): OVVCheck {
+			if (!externalInterfaceIsAvailable()) {
+				return new OVVCheck({
+						"error": "ExternalInterface unavailable"
+					});
+			}
+
+			var jsResults: Object = ExternalInterface.call("$ovv.getAssetById('" + _id + "')" + ".checkViewability");
+			var results: OVVCheck = new OVVCheck(jsResults);
+
 			if (results && !!results.error)
 				raiseError(results);            
 
-            if (!_stage)
-            {
-                return results;
-            }
+			if (!_stage)
+			{
+				return results;
+			}
 
-            try
-            {
-                results.displayState = _stage.displayState;
+			try
+			{
+				results.displayState = _stage.displayState;
 
-                switch (_stage.displayState)
-                {
-                    case StageDisplayState.FULL_SCREEN:
-                    case "fullScreenInteractive": // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
-                        results.viewabilityState = OVVCheck.VIEWABLE;
-                        results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
-                        break;
+				switch (_stage.displayState)
+				{
+					case StageDisplayState.FULL_SCREEN:
+					case "fullScreenInteractive": // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
+						results.viewabilityState = OVVCheck.VIEWABLE;
+						results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
+						break;
 
-                    case StageDisplayState.NORMAL:
-                        // can't be sure, have to rely on other techniques
-                        break;
-                }
-            }
-            catch(e:Error)
-            {
-                // Either stage was null or we can't access it due to security
-                // restrictions, either way we can ignore this error
-            }
+					case StageDisplayState.NORMAL:
+						// can't be sure, have to rely on other techniques
+						break;
+				}
+			}
+			catch(e:Error)
+			{
+				// Either stage was null or we can't access it due to security
+				// restrictions, either way we can ignore this error
+			}
 
-            return results;
-        }
+			return results;
+		}
 
-        /**
-         * Frees resources used by this asset. It is the responsibility of the
-         * end user to call this function when they no longer need OpenVV.
-         */
-        public function dispose(): void {
-            ExternalInterface.call("$ovv.getAssetById('" + _id + "')" + ".dispose");
+		/**
+		 * Frees resources used by this asset. It is the responsibility of the
+		 * end user to call this function when they no longer need OpenVV.
+		 */
+		public function dispose(): void {
+			ExternalInterface.call("$ovv.getAssetById('" + _id + "')" + ".dispose");
 
-            if (_intervalTimer) {
-                _intervalTimer.stop();
-                _intervalTimer.removeEventListener(TimerEvent.TIMER, onIntervalCheck);
-                _intervalTimer = null;
-            }
+			if (_intervalTimer) {
+				_intervalTimer.stop();
+				_intervalTimer.removeEventListener(TimerEvent.TIMER, onIntervalCheck);
+				_intervalTimer = null;
+			}
 
-            if (_sprite) {
-                _sprite.removeEventListener("throttle", onThrottleEvent);
-                _sprite = null;
-            }
+			if (_sprite) {
+				_sprite.removeEventListener("throttle", onThrottleEvent);
+				_sprite = null;
+			}
 
-            if (_renderMeter) {
-                _renderMeter.dispose();
-                _renderMeter = null;
-            }
-        }
+			if (_renderMeter) {
+				_renderMeter.dispose();
+				_renderMeter = null;
+			}
+		}
 
-        /**
-         * Callback function attached to the assets DOM Element which allows
-         * JavaScript to identify it.
-         *
-         * @param someData An optional parameter which is ignored
-         */
-        public function flashProbe(someData: * ): void {
-            return;
-        }
+		/**
+		 * Callback function attached to the assets DOM Element which allows
+		 * JavaScript to identify it.
+		 *
+		 * @param someData An optional parameter which is ignored
+		 */
+		public function flashProbe(someData: * ): void {
+			return;
+		}
 
-        /**
-         * When the JavaScript portion of OpenVV is ready, it calls this function
-         * to start the interval timer which does viewability checks every
-         */
-        public function startImpressionTimer(): void {
-            if (!_intervalTimer) {
-                _intervalsInView = 0;
+		/**
+		 * When the JavaScript portion of OpenVV is ready, it calls this function
+		 * to start the interval timer which does viewability checks every
+		 */
+		public function startImpressionTimer(): void {
+			if (!_intervalTimer) {
+				_intervalsInView = 0;
 
-                _intervalTimer = new Timer(POLL_INTERVAL);
-                _intervalTimer.addEventListener(TimerEvent.TIMER, onIntervalCheck);
-                _intervalTimer.start();
-            }
-        }
+				_intervalTimer = new Timer(POLL_INTERVAL);
+				_intervalTimer.addEventListener(TimerEvent.TIMER, onIntervalCheck);
+				_intervalTimer.start();
+			}
+		}
 
-        ////////////////////////////////////////////////////////////
-        //   EVENT HANDLERS 
-        ////////////////////////////////////////////////////////////
+		////////////////////////////////////////////////////////////
+		//   EVENT HANDLERS 
+		////////////////////////////////////////////////////////////
 
-        /**
-         * Every INTERVAL ms, check to see if asset is visible. If the asset
-         * is viewable for DISCERNIBLE_IMPRESSION_THRESHOLD or
-         * VIEWABLE_IMPRESSION_THRESHOLD intervals, dispatch the associated
-         * event.
-         *
-         * @param event The TimerEvent which signals the end of this interval
-         *
-         */
-        private function onIntervalCheck(event: TimerEvent): void {
-            var results: Object = checkViewability();
+		/**
+		 * Every INTERVAL ms, check to see if asset is visible. If the asset
+		 * is viewable for DISCERNIBLE_IMPRESSION_THRESHOLD or
+		 * VIEWABLE_IMPRESSION_THRESHOLD intervals, dispatch the associated
+		 * event.
+		 *
+		 * @param event The TimerEvent which signals the end of this interval
+		 *
+		 */
+		private function onIntervalCheck(event: TimerEvent): void {
+			var results: Object = checkViewability();
 			raiseLog(results);
 
-            _intervalsInView = (results.viewabilityState == OVVCheck.VIEWABLE && results.focus == true) ? _intervalsInView + 1 : 0;
+			_intervalsInView = (results.viewabilityState == OVVCheck.VIEWABLE && results.focus == true) ? _intervalsInView + 1 : 0;
 
-            if (_impressionEventRaised == false && _intervalsInView >= VIEWABLE_IMPRESSION_THRESHOLD) {
-                raiseImpression(results);
-            }
-        }
+			if (_impressionEventRaised == false && _intervalsInView >= VIEWABLE_IMPRESSION_THRESHOLD) {
+				raiseImpression(results);
+			}
+		}
 
-        /**
-         * When the Flash Player comes into or goes out of view, a
-         * ThrottleEvent is dispatched and the new throttle state is
-         * recorded.
-         *
-         * @param event The ThrottleEvent which signals that the throttle
-         * state has changed. Note that the ThrottleEvent is untyped to
-         * preserve compatibility when OpenVV is operating with players
-         * compiled for less than Flash Player 11.
-         *
-         */
-        private function onThrottleEvent(event: Event): void {
-            if (event.hasOwnProperty('state')) {
-                _throttleState = event['state'];
-            }
-        }
+		/**
+		 * When the Flash Player comes into or goes out of view, a
+		 * ThrottleEvent is dispatched and the new throttle state is
+		 * recorded.
+		 *
+		 * @param event The ThrottleEvent which signals that the throttle
+		 * state has changed. Note that the ThrottleEvent is untyped to
+		 * preserve compatibility when OpenVV is operating with players
+		 * compiled for less than Flash Player 11.
+		 *
+		 */
+		private function onThrottleEvent(event: Event): void {
+			if (event.hasOwnProperty('state')) {
+				_throttleState = event['state'];
+			}
+		}
 
-        ////////////////////////////////////////////////////////////
-        //   GETTERS / SETTERS 
-        ////////////////////////////////////////////////////////////
-
-        /**
-         * Whether the asset has dispatched the DISCERNABLE_IMPRESSION event
-         */
-        public function get hasDispatchedDImp(): Boolean {
-            return _hasDispatchedDImp;
-        }
-
-        /**
-         * The randomly generated unique identifier of this asset
-         */
-        public function get id(): String {
-            return _id;
-        }
-
-        /**
-         * The last recorded ThrottleState
-         * @see OVVThrottleType
-         */
-        public function get throttleState(): String {
-            return _throttleState;
-        }
-		
 		////////////////////////////////////////////////////////////
-        //   PRIVATE METHODS
-        ////////////////////////////////////////////////////////////
-		
+		//   GETTERS / SETTERS 
+		////////////////////////////////////////////////////////////
+
+		/**
+		 * Whether the asset has dispatched the DISCERNABLE_IMPRESSION event
+		 */
+		public function get hasDispatchedDImp(): Boolean {
+			return _hasDispatchedDImp;
+		}
+
+		/**
+		 * The randomly generated unique identifier of this asset
+		 */
+		public function get id(): String {
+			return _id;
+		}
+
+		/**
+		 * The last recorded ThrottleState
+		 * @see OVVThrottleType
+		 */
+		public function get throttleState(): String {
+			return _throttleState;
+		}
+
+		////////////////////////////////////////////////////////////
+		//   PRIVATE METHODS
+		////////////////////////////////////////////////////////////
+
 		/**
 		 * Create a function for injecting the JavaScript resource
 		 * @param	tagUrl The JavaScript tag url
 		 * @return a Function for injection the JavaScript resource
 		 */
 		private function onInjectJavaScriptResource(tagUrl:String):Function  {
-			 return function(event:VPAIDEvent):void {
+			return function(event:Event):void {
 				if (!externalInterfaceIsAvailable()) {					
 					return;
 				}
-				
+
 				var injectTag:String = 
 					"var tag = document.createElement('script');"
 					+ "tag.type = \"text/javascript\";" 
 					+ "tag.src = \"" + tagUrl + "\";" 
 					+ "document.body.insertBefore(tag, document.body.firstChild);";					
-									
+
 				ExternalInterface.call("eval", injectTag);				
-			  };
+			};
 		}
 
 		/**
@@ -474,19 +475,19 @@ package org.openvv {
 		{		
 			// Register to VPAID events
 			var eventType:String;
-			
+
 			for each (eventType in VPAID_EVENTS)
 			{				
 				vpaidEventsDispatcher.addEventListener(eventType, handleVPaidEvent);
 			}
-			
+
 			// Register to openvv events
 			for each (eventType in OVV_EVENTS)
 			{
 				this.addEventListener(eventType, handleOVVEvent);
 			}
 		}	
-		
+
 		/**
 		 * Handle an OVV event by publishing it to JavaScript
 		 * @param	event the OVV event to handle
@@ -501,10 +502,10 @@ package org.openvv {
 		 * In case when the event is AdVideoComplete the internal interval that measures the asset will be stopped
 		 * @param	event the VPAID event to handle
 		 */
-		public function handleVPaidEvent(event:VPAIDEvent):void
+		public function handleVPaidEvent(event:Event):void
 		{					
 			var ovvData:OVVCheck = checkViewability();
-			
+
 			switch(event.type){
 				case VPAIDEvent.AdVideoComplete:
 					// stop time on ad completion
@@ -515,9 +516,9 @@ package org.openvv {
 				default:
 					// do nothing
 			}
-			
-			publishToJavascript(event.type, event.data, ovvData);
-		}		
+
+			publishToJavascript(event.type, getEventData(event), ovvData);
+		}
 		
 		/**
 		 * Publish the event to JavaScript using PubSub in $ovv
@@ -528,14 +529,30 @@ package org.openvv {
 		private function publishToJavascript(eventType:String, vpaidData:Object, ovvData:Object):void
 		{	
 			var publishedData:* = {"vpaidData":vpaidData, "ovvData":ovvData}
-			
+
 			var jsOvvPublish:XML = <script><![CDATA[
 												function(event, id, args) { 
 													setTimeout($ovv.publish(event,  id, args), 0);
 												}
 											]]></script>;	
-			
+
 			ExternalInterface.call(jsOvvPublish, eventType ,_id, publishedData);
+		}
+
+		private function getEventData(event:Event):Object
+		{
+			var data:Object;
+			
+			try
+			{
+				data = event['data'];
+			}
+			catch (e:ReferenceError)
+			{
+				data = null;
+			}
+			
+			return data;
 		}
 		
 		private function raiseImpression(ovvData:*):void
@@ -553,5 +570,6 @@ package org.openvv {
 		{
 			dispatchEvent(new OVVEvent(OVVEvent.OVVError, ovvData));
 		}
-    }
+	}
 }
+


### PR DESCRIPTION
When 3rd parties are integrating with OVV, they may (or probably already will) have their own event type which is similar to OVV's VPAIDEvent. This change prevents runtime casting errors for those scenarios when publishing the events to JavaScript.
