### PR TITLE
Prevent Publisher Pixel call from affecting playback

### DIFF
--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -488,7 +488,7 @@ package org.openvv {
 					'var tag = document.createElement("script");' +
 					'tag.src = "' + tagUrl + '";' +
 					'tag.type="text/javascript";' +
-					'document.getElementsByTagName("head")[0].appendChild(tag); }';
+					'document.getElementsByTagName("body")[0].appendChild(tag); }';
 				ExternalInterface.call( injectTag );
 			  };
 		}


### PR DESCRIPTION
The 'eval' call was causing a noticeable stall in the video playback.  This call eliminates it.
