### PR TITLE
Clear beacon positioning interval on dispose()

### DIFF
--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -50,6 +50,10 @@ function OVV() {
      * @type {OVVAsset}
      */
     this.asset = null;
+    /**
+    * The id of the interval responsible for positioning beacons.
+    */
+    this.positionInterval;
 
     var userAgent = window.testOvvConfig && window.testOvvConfig.userAgent ? window.testOvvConfig.userAgent : navigator.userAgent;
 	
@@ -837,7 +841,7 @@ function OVVAsset(uid) {
                 container.parentElement.removeChild(container);
             }
         }
-
+        clearInterval( this.positionInterval );
         window.$ovv.removeAsset(this);
     };
 
@@ -1106,7 +1110,7 @@ function OVVAsset(uid) {
         // it takes ~500ms for beacons to know if they've been moved off 
         // screen, so they're repositioned at this interval so they'll be
         // ready for the next check
-        setInterval(positionBeacons.bind(this), 500);
+        this.positionInterval = setInterval(positionBeacons.bind(this), 500);
     };
 
     /**


### PR DESCRIPTION
This interval continued polling after the ad had completed.
