### PR TITLE
Clear Beacon positioning interval on dispose()

### DIFF
--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -841,7 +841,7 @@ function OVVAsset(uid) {
                 container.parentElement.removeChild(container);
             }
         }
-        clearInterval( this.positionInterval );
+        clearInterval( window.$ovv.positionInterval );
         window.$ovv.removeAsset(this);
     };
 


### PR DESCRIPTION
This prevents the interval from running after the ad has completed.
