### PR TITLE
Allow secure OVVBeacon to accept calls from a non-secure page.

### DIFF
--- a/src/org/openvv/OVVBeacon.as
+++ b/src/org/openvv/OVVBeacon.as
@@ -96,6 +96,7 @@ package org.openvv {
             super();
 
             Security.allowDomain("*");
+            Security.allowInsecureDomain("*");
 
             _id = loaderInfo.parameters.id;
             _index = loaderInfo.parameters.index;


### PR DESCRIPTION
Serving a secure ad, where the OVVBeacon is served from a secure domain, while in a non-secure page generated JS runtime exception in the attempt to invoke a method in the OVVBeacon.
