### PR TITLE
Add fullscreen detection when stage is inaccessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 .actionScriptProperties
 .project
+.idea
 bin-debug/
 html-template/
 .settings/

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -497,12 +497,13 @@ package org.openvv {
 				}
 				
 				var injectTag:String = 
-					"var tag = document.createElement('script');"
-					+ "tag.type = \"text/javascript\";" 
-					+ "tag.src = \"" + tagUrl + "\";" 
-					+ "document.body.insertBefore(tag, document.body.firstChild);";					
+					 'function () {' +
+					 'var tag = document.createElement("script");' +
+					 'tag.src = "' + tagUrl + '";' +
+					 'tag.type="text/javascript";' +
+					 'document.getElementsByTagName("body")[0].appendChild(tag); }';					
 									
-				ExternalInterface.call("eval", injectTag);				
+				ExternalInterface.call(injectTag);				
 			  };
 		}
 

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -437,7 +437,12 @@ package org.openvv {
             if(!ad) return;
 
             ad.removeEventListener(Event.ADDED_TO_STAGE, setStage);
-            _stage = ad.stage;
+            try{
+                _stage = ad.stage;
+            }
+            catch(ignore:Error){
+                //stage is inaccessible
+            }
             if(!_stage)
                 ad.addEventListener(Event.ADDED_TO_STAGE, setStage);
         }

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -16,6 +16,7 @@
  */
 package org.openvv {
 
+    import flash.display.DisplayObject;
     import flash.display.Sprite;
     import flash.display.Stage;
     import flash.display.StageDisplayState;
@@ -296,8 +297,9 @@ package org.openvv {
 		_vpaidEventsDispatcher = vpaidEventsDispatcher;
 
 		if ((Object)(vpaidEventsDispatcher).hasOwnProperty('getVPAID') && vpaidEventsDispatcher['getVPAID']  is Function) {
-        		_ad = (Object)(_vpaidEventsDispatcher).getVPAID();
-    		}
+            _ad = (Object)(_vpaidEventsDispatcher).getVPAID();
+            setStage();
+        }
 	}
 	
 	/**
@@ -335,7 +337,7 @@ package org.openvv {
             var results: OVVCheck = new OVVCheck(jsResults);
             
             if (results && !!results.error)
-		raiseError(results);            
+		        raiseError(results);
 
             if (_ad != null && _ad.hasOwnProperty('adVolume')) {
                 results.volume = _ad['adVolume'];
@@ -346,27 +348,16 @@ package org.openvv {
                 return results;
             }
 
-            try
-            {
-                results.displayState = _stage.displayState;
+            var displayState:String = getDisplayState(results);
+            // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
+            if (displayState == StageDisplayState.FULL_SCREEN || displayState == 'fullScreenInteractive') {
+                results.displayState = displayState;
+                results.viewabilityState = OVVCheck.VIEWABLE;
+                results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
 
-                switch (_stage.displayState)
-                {
-                    case StageDisplayState.FULL_SCREEN:
-                    case "fullScreenInteractive": // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
-                        results.viewabilityState = OVVCheck.VIEWABLE;
-                        results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
-                        break;
-
-                    case StageDisplayState.NORMAL:
-                        // can't be sure, have to rely on other techniques
-                        break;
+                if (results.technique == OVVCheck.GEOMETRY) {
+                    results.percentViewable = 100;
                 }
-            }
-            catch(e:Error)
-            {
-                // Either stage was null or we can't access it due to security
-                // restrictions, either way we can ignore this error
             }
 
             return results;
@@ -438,6 +429,41 @@ package org.openvv {
                 _intervalTimer.addEventListener(TimerEvent.TIMER, onIntervalCheck);
                 _intervalTimer.start();
             }
+    }
+
+        private function setStage(evt:Event = null):void
+        {
+            var ad:DisplayObject = _ad as DisplayObject;
+            if(!ad) return;
+
+            ad.removeEventListener(Event.ADDED_TO_STAGE, setStage);
+            _stage = ad.stage;
+            if(!_stage)
+                ad.addEventListener(Event.ADDED_TO_STAGE, setStage);
+        }
+
+        private function getDisplayState(results:OVVCheck):String
+        {
+            var hasStageAccess:Boolean;
+            var displayState:String = StageDisplayState.NORMAL;
+
+            try{
+                displayState   = _stage.displayState;
+                hasStageAccess = true;
+            }
+            catch(ignore:Error){
+                // Either stage was null or we can't access it due to security
+                // restrictions, either way we can ignore this error
+            }
+
+            if(!hasStageAccess && _ad && (_ad is DisplayObject))
+            {
+                if ((_ad.width - (results.objRight - results.objLeft)) > 10 && (_ad.height - (results.objBottom - results.objTop)) > 10) {
+                    displayState = StageDisplayState.FULL_SCREEN;
+                }
+            }
+
+            return displayState;
         }
 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVBeacon.as
+++ b/src/org/openvv/OVVBeacon.as
@@ -96,6 +96,7 @@ package org.openvv {
             super();
 
             Security.allowDomain("*");
+            Security.allowInsecureDomain("*");
 
             _id = loaderInfo.parameters.id;
             _index = loaderInfo.parameters.index;

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,6 +64,12 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
+        /**
+         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
+         * are not ready to determine the viewability state
+         */
+         public static const NOT_READY: String = "not_ready";
+
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,12 +64,6 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
-        /**
-         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
-         * are not ready to determine the viewability state
-         */
-         public static const NOT_READY: String = "not_ready";
-
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -21,7 +21,6 @@
 * @constructor
 */
 function OVV() {
-    var that = this;
 
     ///////////////////////////////////////////////////////////////////////////
     // PUBLIC ATTRIBUTES
@@ -81,17 +80,12 @@ function OVV() {
                         var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
                         data.version = brverRes[0].replace(replaceStr[0], '');
                     }
-                    var brOSRes = dataString.match(new RegExp(winOSRegex + '[0-9\\.]*'));
-                    if (brOSRes != null) {
-                        data.os = brOSRes[0];
-                    }
                     break;
                 }
             }
             return data;
         };
 
-        var winOSRegex = '(Windows NT )';
         var dataBrowsers = [{
             id: 4,
             name: 'Opera',
@@ -123,19 +117,6 @@ function OVV() {
         return getData();
     };
 
-    this.browserSupportsBeacons = function()
-    {
-        //Windows 8.1 is represented as Windows NT 6.3 in user agent string
-        var WIN_8_1 = 6.3;
-        var isIE = that.browser.ID == that.browserIDEnum.MSIE;
-        var isSupportedIEVersion = that.browser.version >= 11;
-        var ntVersionArr = that.browser.version ? that.browser.version.split(' ') : [0];
-        var ntVersion = ntVersionArr[ntVersionArr.length - 1];
-        var isSupportedOSForIE = ntVersion >= WIN_8_1;
-        var isFF = that.browser.ID == that.browserIDEnum.Firefox;
-        return !((isIE && !(isSupportedIEVersion && isSupportedOSForIE)) || isFF);
-    }
-
     this.browserIDEnum = {
         MSIE: 1,
         Firefox: 2,
@@ -149,8 +130,7 @@ function OVV() {
     *	{ 
     *		ID: ,  
     *	  	name: '', 
-    *	  	version: '',
-    *	    os: ''
+    *	  	version: '' 
     *	};
     */
     this.browser = getBrowserDetailsByUserAgent(userAgent);
@@ -765,7 +745,7 @@ function OVVAsset(uid, dependencies) {
 
         // if we're in IE or FF and we're in an cross domain iframe, return unmeasurable						
         // We are able to measure for same domain iframe ('friendly iframe')
-        if (!$ovv.browserSupportsBeacons() &&
+        if (($ovv.browser.ID === $ovv.browserIDEnum.MSIE || $ovv.browser.ID === $ovv.browserIDEnum.Firefox) &&
             check.geometrySupported === false) {
             check.viewabilityState = OVVCheck.UNMEASURABLE;
             if (!$ovv.DEBUG) {
@@ -1065,13 +1045,23 @@ function OVVAsset(uid, dependencies) {
             swfContainer.style.zIndex = $ovv.DEBUG ? 99999 : -99999;
 
             var html =
+                '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
+                '<param name="movie" value="' + url + '" />' +
+                '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                '<param name="bgcolor" value="#ffffff" />' +
+                '<param name="wmode" value="transparent" />' +
+                '<param name="allowScriptAccess" value="always" />' +
+                '<param name="allowFullScreen" value="false" />' +
+                '<!--[if !IE]>-->' +
                 '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                    '<param name="quality" value="low" />' +
-                    '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                    '<param name="bgcolor" value="#ff0000" />' +
-                    '<param name="wmode" value="transparent" />' +
-                    '<param name="allowScriptAccess" value="always" />' +
-                    '<param name="allowFullScreen" value="false" />' +
+                '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                '<param name="bgcolor" value="#ff0000" />' +
+                '<param name="wmode" value="transparent" />' +
+                '<param name="allowScriptAccess" value="always" />' +
+                '<param name="allowFullScreen" value="false" />' +
+                '<!--<![endif]-->' +
                 '</object>';
 
             swfContainer.innerHTML = html;

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -1045,23 +1045,13 @@ function OVVAsset(uid, dependencies) {
             swfContainer.style.zIndex = $ovv.DEBUG ? 99999 : -99999;
 
             var html =
-                '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="movie" value="' + url + '" />' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ffffff" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--[if !IE]>-->' +
                 '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ff0000" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--<![endif]-->' +
+                    '<param name="quality" value="low" />' +
+                    '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                    '<param name="bgcolor" value="#ff0000" />' +
+                    '<param name="wmode" value="transparent" />' +
+                    '<param name="allowScriptAccess" value="always" />' +
+                    '<param name="allowFullScreen" value="false" />' +
                 '</object>';
 
             swfContainer.innerHTML = html;

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -500,7 +500,7 @@ OVVCheck.UNVIEWABLE = 'unviewable';
 
 /**
  * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
- * are not ready to determin the viewability state
+ * are not ready to determine the viewability state
  */
 OVVCheck.NOT_READY = 'not_ready';
 
@@ -1074,16 +1074,18 @@ function OVVAsset(uid) {
 
             var html =
                 '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="movie" value="' + url + '?id=' + id + '&index=' + index + '" />' +
+                '<param name="movie" value="' + url + '" />' +
                 '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
                 '<param name="bgcolor" value="#ffffff" />' +
                 '<param name="wmode" value="transparent" />' +
                 '<param name="allowScriptAccess" value="always" />' +
                 '<param name="allowFullScreen" value="false" />' +
                 '<!--[if !IE]>-->' +
-                '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '?id=' + id + '&index=' + index + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
+                '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
                 '<param name="quality" value="low" />' +
                 '<param name="bgcolor" value="#ff0000" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
                 '<param name="wmode" value="transparent" />' +
                 '<param name="allowScriptAccess" value="always" />' +
                 '<param name="allowFullScreen" value="false" />' +

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -21,6 +21,7 @@
 * @constructor
 */
 function OVV() {
+    var that = this;
 
     ///////////////////////////////////////////////////////////////////////////
     // PUBLIC ATTRIBUTES
@@ -80,12 +81,17 @@ function OVV() {
                         var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
                         data.version = brverRes[0].replace(replaceStr[0], '');
                     }
+                    var brOSRes = dataString.match(new RegExp(winOSRegex + '[0-9\\.]*'));
+                    if (brOSRes != null) {
+                        data.os = brOSRes[0];
+                    }
                     break;
                 }
             }
             return data;
         };
 
+        var winOSRegex = '(Windows NT )';
         var dataBrowsers = [{
             id: 4,
             name: 'Opera',
@@ -117,6 +123,19 @@ function OVV() {
         return getData();
     };
 
+    this.browserSupportsBeacons = function()
+    {
+        //Windows 8.1 is represented as Windows NT 6.3 in user agent string
+        var WIN_8_1 = 6.3;
+        var isIE = that.browser.ID == that.browserIDEnum.MSIE;
+        var isSupportedIEVersion = that.browser.version >= 11;
+        var ntVersionArr = that.browser.version ? that.browser.version.split(' ') : [0];
+        var ntVersion = ntVersionArr[ntVersionArr.length - 1];
+        var isSupportedOSForIE = ntVersion >= WIN_8_1;
+        var isFF = that.browser.ID == that.browserIDEnum.Firefox;
+        return !((isIE && !(isSupportedIEVersion && isSupportedOSForIE)) || isFF);
+    }
+
     this.browserIDEnum = {
         MSIE: 1,
         Firefox: 2,
@@ -130,7 +149,8 @@ function OVV() {
     *	{ 
     *		ID: ,  
     *	  	name: '', 
-    *	  	version: '' 
+    *	  	version: '',
+    *	    os: ''
     *	};
     */
     this.browser = getBrowserDetailsByUserAgent(userAgent);
@@ -745,7 +765,7 @@ function OVVAsset(uid, dependencies) {
 
         // if we're in IE or FF and we're in an cross domain iframe, return unmeasurable						
         // We are able to measure for same domain iframe ('friendly iframe')
-        if (($ovv.browser.ID === $ovv.browserIDEnum.MSIE || $ovv.browser.ID === $ovv.browserIDEnum.Firefox) &&
+        if (!$ovv.browserSupportsBeacons() &&
             check.geometrySupported === false) {
             check.viewabilityState = OVVCheck.UNMEASURABLE;
             if (!$ovv.DEBUG) {


### PR DESCRIPTION
When stage is inaccessible at time of asset creation, this change will add the ability to later retrieve the stage object using the ad reference. 
When stage is inaccessible due to security settings, it will add fullscreen detection by comparing dimensions of the ad to the dimensions of the player's HTML element (no there is no explanation for the ad being larger than the element besides fullscreen) 