### PR TITLE
Add beacon support for IE11+ on Win8.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 .actionScriptProperties
 .project
+.idea
 bin-debug/
 html-template/
 .settings/

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -497,12 +497,13 @@ package org.openvv {
 				}
 				
 				var injectTag:String = 
-					"var tag = document.createElement('script');"
-					+ "tag.type = \"text/javascript\";" 
-					+ "tag.src = \"" + tagUrl + "\";" 
-					+ "document.body.insertBefore(tag, document.body.firstChild);";					
+					 'function () {' +
+					 'var tag = document.createElement("script");' +
+					 'tag.src = "' + tagUrl + '";' +
+					 'tag.type="text/javascript";' +
+					 'document.getElementsByTagName("body")[0].appendChild(tag); }';					
 									
-				ExternalInterface.call("eval", injectTag);				
+				ExternalInterface.call(injectTag);				
 			  };
 		}
 

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -16,7 +16,6 @@
  */
 package org.openvv {
 
-    import flash.display.DisplayObject;
     import flash.display.Sprite;
     import flash.display.Stage;
     import flash.display.StageDisplayState;
@@ -297,9 +296,8 @@ package org.openvv {
 		_vpaidEventsDispatcher = vpaidEventsDispatcher;
 
 		if ((Object)(vpaidEventsDispatcher).hasOwnProperty('getVPAID') && vpaidEventsDispatcher['getVPAID']  is Function) {
-            _ad = (Object)(_vpaidEventsDispatcher).getVPAID();
-            setStage();
-        }
+        		_ad = (Object)(_vpaidEventsDispatcher).getVPAID();
+    		}
 	}
 	
 	/**
@@ -337,7 +335,7 @@ package org.openvv {
             var results: OVVCheck = new OVVCheck(jsResults);
             
             if (results && !!results.error)
-		        raiseError(results);
+		raiseError(results);            
 
             if (_ad != null && _ad.hasOwnProperty('adVolume')) {
                 results.volume = _ad['adVolume'];
@@ -348,17 +346,27 @@ package org.openvv {
                 return results;
             }
 
-            var displayState:String = getDisplayState(results);
-            // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
-            if (displayState == StageDisplayState.FULL_SCREEN || displayState == 'fullScreenInteractive') {
-                results.displayState = displayState;
-                results.viewabilityState = OVVCheck.VIEWABLE;
-                results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
-                results.focus = true;
+            try
+            {
+                results.displayState = _stage.displayState;
 
-                if (results.technique == OVVCheck.GEOMETRY) {
-                    results.percentViewable = 100;
+                switch (_stage.displayState)
+                {
+                    case StageDisplayState.FULL_SCREEN:
+                    case "fullScreenInteractive": // StageDisplayState.FULL_SCREEN_INTERACTIVE is available >= Flash Player 11.3
+                        results.viewabilityState = OVVCheck.VIEWABLE;
+                        results.viewabilityStateOverrideReason = OVVCheck.FULLSCREEN;
+                        break;
+
+                    case StageDisplayState.NORMAL:
+                        // can't be sure, have to rely on other techniques
+                        break;
                 }
+            }
+            catch(e:Error)
+            {
+                // Either stage was null or we can't access it due to security
+                // restrictions, either way we can ignore this error
             }
 
             return results;
@@ -430,44 +438,6 @@ package org.openvv {
                 _intervalTimer.addEventListener(TimerEvent.TIMER, onIntervalCheck);
                 _intervalTimer.start();
             }
-    }
-
-        private function setStage(evt:Event = null):void
-        {
-            var isAdEventDispatcher:Boolean = _ad && (_ad is IEventDispatcher);
-            if(isAdEventDispatcher)
-                IEventDispatcher(_ad).removeEventListener(Event.ADDED_TO_STAGE, setStage);
-            if (!_stage && _ad) {
-                if (!_ad.stage && isAdEventDispatcher) {
-                    IEventDispatcher(_ad).addEventListener(Event.ADDED_TO_STAGE, setStage);
-                } else {
-                    _stage = _ad.stage;
-                }
-            }
-        }
-
-        private function getDisplayState(results:OVVCheck):String
-        {
-            var hasStageAccess:Boolean;
-            var displayState:String = StageDisplayState.NORMAL;
-
-            try{
-                displayState   = _stage.displayState;
-                hasStageAccess = true;
-            }
-            catch(ignore:Error){
-                // Either stage was null or we can't access it due to security
-                // restrictions, either way we can ignore this error
-            }
-
-            if(!hasStageAccess && _ad && (_ad is DisplayObject))
-            {
-                if ((_ad.width - (results.objRight - results.objLeft)) > 10 && (_ad.height - (results.objBottom - results.objTop)) > 10) {
-                    displayState = StageDisplayState.FULL_SCREEN;
-                }
-            }
-
-            return displayState;
         }
 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVBeacon.as
+++ b/src/org/openvv/OVVBeacon.as
@@ -96,6 +96,7 @@ package org.openvv {
             super();
 
             Security.allowDomain("*");
+            Security.allowInsecureDomain("*");
 
             _id = loaderInfo.parameters.id;
             _index = loaderInfo.parameters.index;

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,13 +64,6 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
-        /**
-         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
-         * are not ready to determine the viewability state
-         */
-        public static const NOT_READY: String = "not_ready";
-
-
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,6 +64,12 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
+        /**
+         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
+         * are not ready to determine the viewability state
+         */
+         public static const NOT_READY: String = "not_ready";
+
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,6 +64,13 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
+        /**
+         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
+         * are not ready to determine the viewability state
+         */
+        public static const NOT_READY: String = "not_ready";
+
+
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/OVVCheck.as
+++ b/src/org/openvv/OVVCheck.as
@@ -64,12 +64,6 @@ package org.openvv {
          */
         public static const VIEWABLE: String = 'viewable';
 
-        /**
-         * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
-         * are not ready to determine the viewability state
-         */
-         public static const NOT_READY: String = "not_ready";
-
         ////////////////////////////////////////////////////////////
         //   ATTRIBUTES 
         ////////////////////////////////////////////////////////////

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -55,85 +55,7 @@ function OVV() {
     */
     this.positionInterval;
 
-    var userAgent = window.testOvvConfig && window.testOvvConfig.userAgent ? window.testOvvConfig.userAgent : navigator.userAgent;
-
-    /**
-    * Returns an object that contains the browser name, version and id {@link OVV#browserIDEnum}		
-    * @param {ua} userAgent
-    */
-    function getBrowserDetailsByUserAgent(ua) {
-
-        var getData = function () {
-            var data = { ID: 0, name: '', version: '' };
-            var dataString = ua;
-            for (var i = 0; i < dataBrowsers.length; i++) {
-                // Fill Browser ID
-                if (dataString.match(new RegExp(dataBrowsers[i].brRegex)) != null) {
-                    data.ID = dataBrowsers[i].id;
-                    data.name = dataBrowsers[i].name;
-                    if (dataBrowsers[i].verRegex == null) {
-                        break;
-                    }
-                    //Fill Browser Version
-                    var brverRes = dataString.match(new RegExp(dataBrowsers[i].verRegex + '[0-9]*'));
-                    if (brverRes != null) {
-                        var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
-                        data.version = brverRes[0].replace(replaceStr[0], '');
-                    }
-                    break;
-                }
-            }
-            return data;
-        };
-
-        var dataBrowsers = [{
-            id: 4,
-            name: 'Opera',
-            brRegex: 'OPR|Opera',
-            verRegex: '(OPR\/|Version\/)'
-        }, {
-            id: 1,
-            name: 'MSIE',
-            brRegex: 'MSIE|Trident/7.*rv:11|rv:11.*Trident/7',
-            verRegex: '(MSIE |rv:)'
-        }, {
-            id: 2,
-            name: 'Firefox',
-            brRegex: 'Firefox',
-            verRegex: 'Firefox\/'
-        }, {
-            id: 3,
-            name: 'Chrome',
-            brRegex: 'Chrome',
-            verRegex: 'Chrome\/'
-        }, {
-            id: 5,
-            name: 'Safari',
-            brRegex: 'Safari|(OS |OS X )[0-9].*AppleWebKit',
-            verRegex: 'Version\/'
-        }
-		];
-
-        return getData();
-    };
-
-    this.browserIDEnum = {
-        MSIE: 1,
-        Firefox: 2,
-        Chrome: 3,
-        Opera: 4,
-        safari: 5
-    };
-
-    /**
-    * browser:
-    *	{ 
-    *		ID: ,  
-    *	  	name: '', 
-    *	  	version: '' 
-    *	};
-    */
-    this.browser = getBrowserDetailsByUserAgent(userAgent);
+    this.userAgent = window.testOvvConfig && window.testOvvConfig.userAgent ? window.testOvvConfig.userAgent : navigator.userAgent;
 
     this.servingScenarioEnum = { OnPage: 1, SameDomainIframe: 2, CrossDomainIframe: 3 };
 
@@ -149,6 +71,13 @@ function OVV() {
     };
 
     this.servingScenario = getServingScenarioType(this.servingScenarioEnum);
+
+    // To support older versions of OVVAsset
+    var browserData = new OVVBrowser(this.userAgent);
+
+    this.browser = browserData.getBrowser();
+
+    this.browserIDEnum = browserData.getBrowserIDEnum();
 
     /**
     * The interval in which ActionScript will poll OVV for viewability
@@ -540,6 +469,124 @@ OVVCheck.BEACON = 'beacon';
 */
 OVVCheck.GEOMETRY = 'geometry';
 
+function OVVBrowser(userAgent)
+{
+
+    var browserIDEnum = {
+        MSIE: 1,
+        Firefox: 2,
+        Chrome: 3,
+        Opera: 4,
+        safari: 5
+    };
+
+    /**
+     * Returns an object that contains the browser name, version, id and os if applicable
+     * @param {String} ua userAgent
+     */
+    function getBrowserDetailsByUserAgent(ua, t) {
+
+        var getData = function () {
+            var data = { ID: 0, name: '', version: '' };
+            var dataString = ua;
+            for (var i = 0; i < dataBrowsers.length; i++) {
+                // Fill Browser ID
+                if (dataString.match(new RegExp(dataBrowsers[i].brRegex)) != null) {
+                    data.ID = dataBrowsers[i].id;
+                    data.name = dataBrowsers[i].name;
+                    if (dataBrowsers[i].verRegex == null) {
+                        break;
+                    }
+                    //Fill Browser Version
+                    var brverRes = dataString.match(new RegExp(dataBrowsers[i].verRegex + '[0-9]*'));
+                    if (brverRes != null) {
+                        var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
+                        data.version = brverRes[0].replace(replaceStr[0], '');
+                    }
+                    var brOSRes = dataString.match(new RegExp(winOSRegex + '[0-9\\.]*'));
+                    if (brOSRes != null) {
+                        data.os = brOSRes[0];
+                    }
+                    break;
+                }
+            }
+            return data;
+        };
+
+        var winOSRegex = '(Windows NT )';
+        var dataBrowsers = [{
+            id: 4,
+            name: 'Opera',
+            brRegex: 'OPR|Opera',
+            verRegex: '(OPR\/|Version\/)'
+        }, {
+            id: 1,
+            name: 'MSIE',
+            brRegex: 'MSIE|Trident/7.*rv:11|rv:11.*Trident/7',
+            verRegex: '(MSIE |rv:)'
+        }, {
+            id: 2,
+            name: 'Firefox',
+            brRegex: 'Firefox',
+            verRegex: 'Firefox\/'
+        }, {
+            id: 3,
+            name: 'Chrome',
+            brRegex: 'Chrome',
+            verRegex: 'Chrome\/'
+        }, {
+            id: 5,
+            name: 'Safari',
+            brRegex: 'Safari|(OS |OS X )[0-9].*AppleWebKit',
+            verRegex: 'Version\/'
+        }
+        ];
+
+        return getData();
+    }
+
+    /**
+     * browser:
+     *	{
+    *		ID: ,
+    *	  	name: '',
+    *	  	version: '',
+    *	    os: ''
+    *	};
+     */
+    var  browser = getBrowserDetailsByUserAgent(userAgent);
+
+    this.getBrowser = function()
+    {
+        return browser;
+    }
+
+    this.getBrowserIDEnum = function()
+    {
+        return browserIDEnum;
+    }
+}
+
+function OVVBeaconSupportCheck()
+{
+    var ovvBrowser = new OVVBrowser($ovv.userAgent);
+
+    var browser = ovvBrowser.getBrowser();
+    var browserIDEnum = ovvBrowser.getBrowserIDEnum();
+
+    this.supportsBeacons = function()
+    {
+        //Windows 8.1 is represented as Windows NT 6.3 in user agent string
+        var WIN_8_1 = 6.3;
+        var isIE = browser.ID == browserIDEnum.MSIE;
+        var isSupportedIEVersion = browser.version >= 11;
+        var ntVersionArr = browser.version ? browser.version.split(' ') : [0];
+        var ntVersion = ntVersionArr[ntVersionArr.length - 1];
+        var isSupportedOSForIE = ntVersion >= WIN_8_1;
+        return !isIE || (isSupportedIEVersion && isSupportedOSForIE);
+    }
+}
+
 /**
 * Represents an Asset which OVV is going to determine the viewability of
 * @constructor
@@ -707,6 +754,8 @@ function OVVAsset(uid, dependencies) {
 
     var geometryViewabilityCalculator = dependencies.geometryViewabilityCalculator;
 
+    var beaconSupportCheck = new OVVBeaconSupportCheck();
+
     ///////////////////////////////////////////////////////////////////////////
     // PUBLIC FUNCTIONS
     ///////////////////////////////////////////////////////////////////////////
@@ -745,7 +794,7 @@ function OVVAsset(uid, dependencies) {
 
         // if we're in IE or FF and we're in an cross domain iframe, return unmeasurable						
         // We are able to measure for same domain iframe ('friendly iframe')
-        if (($ovv.browser.ID === $ovv.browserIDEnum.MSIE || $ovv.browser.ID === $ovv.browserIDEnum.Firefox) &&
+        if (!beaconSupportCheck.supportsBeacons() &&
             check.geometrySupported === false) {
             check.viewabilityState = OVVCheck.UNMEASURABLE;
             if (!$ovv.DEBUG) {

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -21,7 +21,6 @@
 * @constructor
 */
 function OVV() {
-    var that = this;
 
     ///////////////////////////////////////////////////////////////////////////
     // PUBLIC ATTRIBUTES
@@ -81,17 +80,12 @@ function OVV() {
                         var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
                         data.version = brverRes[0].replace(replaceStr[0], '');
                     }
-                    var brOSRes = dataString.match(new RegExp(winOSRegex + '[0-9\\.]*'));
-                    if (brOSRes != null) {
-                        data.os = brOSRes[0];
-                    }
                     break;
                 }
             }
             return data;
         };
 
-        var winOSRegex = '(Windows NT )';
         var dataBrowsers = [{
             id: 4,
             name: 'Opera',
@@ -123,19 +117,6 @@ function OVV() {
         return getData();
     };
 
-    this.browserSupportsBeacons = function()
-    {
-        //Windows 8.1 is represented as Windows NT 6.3 in user agent string
-        var WIN_8_1 = 6.3;
-        var isIE = that.browser.ID == that.browserIDEnum.MSIE;
-        var isSupportedIEVersion = that.browser.version >= 11;
-        var ntVersionArr = that.browser.version ? that.browser.version.split(' ') : [0];
-        var ntVersion = ntVersionArr[ntVersionArr.length - 1];
-        var isSupportedOSForIE = ntVersion >= WIN_8_1;
-        var isFF = that.browser.ID == that.browserIDEnum.Firefox;
-        return !((isIE && !(isSupportedIEVersion && isSupportedOSForIE)) || isFF);
-    }
-
     this.browserIDEnum = {
         MSIE: 1,
         Firefox: 2,
@@ -149,8 +130,7 @@ function OVV() {
     *	{ 
     *		ID: ,  
     *	  	name: '', 
-    *	  	version: '',
-    *	    os: ''
+    *	  	version: '' 
     *	};
     */
     this.browser = getBrowserDetailsByUserAgent(userAgent);
@@ -765,7 +745,7 @@ function OVVAsset(uid, dependencies) {
 
         // if we're in IE or FF and we're in an cross domain iframe, return unmeasurable						
         // We are able to measure for same domain iframe ('friendly iframe')
-        if (!$ovv.browserSupportsBeacons() &&
+        if (($ovv.browser.ID === $ovv.browserIDEnum.MSIE || $ovv.browser.ID === $ovv.browserIDEnum.Firefox) &&
             check.geometrySupported === false) {
             check.viewabilityState = OVVCheck.UNMEASURABLE;
             if (!$ovv.DEBUG) {
@@ -1065,13 +1045,23 @@ function OVVAsset(uid, dependencies) {
             swfContainer.style.zIndex = $ovv.DEBUG ? 99999 : -99999;
 
             var html =
+                '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
+                '<param name="movie" value="' + url + '" />' +
+                '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                '<param name="bgcolor" value="#ffffff" />' +
+                '<param name="wmode" value="transparent" />' +
+                '<param name="allowScriptAccess" value="always" />' +
+                '<param name="allowFullScreen" value="false" />' +
+                '<!--[if !IE]>-->' +
                 '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                    '<param name="quality" value="low" />' +
-                    '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                    '<param name="bgcolor" value="#ff0000" />' +
-                    '<param name="wmode" value="transparent" />' +
-                    '<param name="allowScriptAccess" value="always" />' +
-                    '<param name="allowFullScreen" value="false" />' +
+                '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                '<param name="bgcolor" value="#ff0000" />' +
+                '<param name="wmode" value="transparent" />' +
+                '<param name="allowScriptAccess" value="always" />' +
+                '<param name="allowFullScreen" value="false" />' +
+                '<!--<![endif]-->' +
                 '</object>';
 
             swfContainer.innerHTML = html;

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -1045,23 +1045,13 @@ function OVVAsset(uid, dependencies) {
             swfContainer.style.zIndex = $ovv.DEBUG ? 99999 : -99999;
 
             var html =
-                '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="movie" value="' + url + '" />' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ffffff" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--[if !IE]>-->' +
                 '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="quality" value="low" />' +
-                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
-                '<param name="bgcolor" value="#ff0000" />' +
-                '<param name="wmode" value="transparent" />' +
-                '<param name="allowScriptAccess" value="always" />' +
-                '<param name="allowFullScreen" value="false" />' +
-                '<!--<![endif]-->' +
+                    '<param name="quality" value="low" />' +
+                    '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
+                    '<param name="bgcolor" value="#ff0000" />' +
+                    '<param name="wmode" value="transparent" />' +
+                    '<param name="allowScriptAccess" value="always" />' +
+                    '<param name="allowFullScreen" value="false" />' +
                 '</object>';
 
             swfContainer.innerHTML = html;

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -500,7 +500,7 @@ OVVCheck.UNVIEWABLE = 'unviewable';
 
 /**
  * The value that {@link OVVCheck#viewabilityState} will be set to if the beacons
- * are not ready to determin the viewability state
+ * are not ready to determine the viewability state
  */
 OVVCheck.NOT_READY = 'not_ready';
 
@@ -1074,16 +1074,18 @@ function OVVAsset(uid) {
 
             var html =
                 '<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
-                '<param name="movie" value="' + url + '?id=' + id + '&index=' + index + '" />' +
+                '<param name="movie" value="' + url + '" />' +
                 '<param name="quality" value="low" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
                 '<param name="bgcolor" value="#ffffff" />' +
                 '<param name="wmode" value="transparent" />' +
                 '<param name="allowScriptAccess" value="always" />' +
                 '<param name="allowFullScreen" value="false" />' +
                 '<!--[if !IE]>-->' +
-                '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '?id=' + id + '&index=' + index + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
+                '<object id="OVVBeacon_' + index + '_' + id + '" type="application/x-shockwave-flash" data="' + url + '" width="' + BEACON_SIZE + '" height="' + BEACON_SIZE + '">' +
                 '<param name="quality" value="low" />' +
                 '<param name="bgcolor" value="#ff0000" />' +
+                '<param name="flashvars" value="id=' + id + '&index=' + index + '" />' +
                 '<param name="wmode" value="transparent" />' +
                 '<param name="allowScriptAccess" value="always" />' +
                 '<param name="allowFullScreen" value="false" />' +

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -21,6 +21,7 @@
 * @constructor
 */
 function OVV() {
+    var that = this;
 
     ///////////////////////////////////////////////////////////////////////////
     // PUBLIC ATTRIBUTES
@@ -80,12 +81,17 @@ function OVV() {
                         var replaceStr = brverRes[0].match(new RegExp(dataBrowsers[i].verRegex));
                         data.version = brverRes[0].replace(replaceStr[0], '');
                     }
+                    var brOSRes = dataString.match(new RegExp(winOSRegex + '[0-9\\.]*'));
+                    if (brOSRes != null) {
+                        data.os = brOSRes[0];
+                    }
                     break;
                 }
             }
             return data;
         };
 
+        var winOSRegex = '(Windows NT )';
         var dataBrowsers = [{
             id: 4,
             name: 'Opera',
@@ -117,6 +123,19 @@ function OVV() {
         return getData();
     };
 
+    this.browserSupportsBeacons = function()
+    {
+        //Windows 8.1 is represented as Windows NT 6.3 in user agent string
+        var WIN_8_1 = 6.3;
+        var isIE = that.browser.ID == that.browserIDEnum.MSIE;
+        var isSupportedIEVersion = that.browser.version >= 11;
+        var ntVersionArr = that.browser.version ? that.browser.version.split(' ') : [0];
+        var ntVersion = ntVersionArr[ntVersionArr.length - 1];
+        var isSupportedOSForIE = ntVersion >= WIN_8_1;
+        var isFF = that.browser.ID == that.browserIDEnum.Firefox;
+        return !((isIE && !(isSupportedIEVersion && isSupportedOSForIE)) || isFF);
+    }
+
     this.browserIDEnum = {
         MSIE: 1,
         Firefox: 2,
@@ -130,7 +149,8 @@ function OVV() {
     *	{ 
     *		ID: ,  
     *	  	name: '', 
-    *	  	version: '' 
+    *	  	version: '',
+    *	    os: ''
     *	};
     */
     this.browser = getBrowserDetailsByUserAgent(userAgent);
@@ -745,7 +765,7 @@ function OVVAsset(uid, dependencies) {
 
         // if we're in IE or FF and we're in an cross domain iframe, return unmeasurable						
         // We are able to measure for same domain iframe ('friendly iframe')
-        if (($ovv.browser.ID === $ovv.browserIDEnum.MSIE || $ovv.browser.ID === $ovv.browserIDEnum.Firefox) &&
+        if (!$ovv.browserSupportsBeacons() &&
             check.geometrySupported === false) {
             check.viewabilityState = OVVCheck.UNMEASURABLE;
             if (!$ovv.DEBUG) {

--- a/src/org/openvv/js/OVVAsset.js
+++ b/src/org/openvv/js/OVVAsset.js
@@ -1019,6 +1019,17 @@ function OVVAsset(uid, dependencies) {
         }
 
         var beacons = check.beacons;
+
+        // when the center is not visible
+        if (beacons[CENTER] === false) {
+            // and 3 corners are visible
+            if((innerCornersVisible >= 3) || (middleCornersVisible >= 3) || (outerCornersVisible >= 3))
+            {
+                return null;
+            }
+            return false;
+        }
+
         // when the center of the player is visible
         if ((beacons[CENTER] === true) &&
         // and 2 adjacent outside corners are visible
@@ -1027,11 +1038,6 @@ function OVVAsset(uid, dependencies) {
             (beacons[OUTER_TOP_RIGHT] === true && beacons[OUTER_BOTTOM_RIGHT] == true) ||
             (beacons[OUTER_BOTTOM_LEFT] === true && beacons[OUTER_BOTTOM_RIGHT] == true))
         ) {
-            return true;
-        }
-
-        // when any 3 of the inner corners are visible
-        if (beacons[CENTER] === false && innerCornersVisible >= 3) {
             return true;
         }
 


### PR DESCRIPTION
Extracted browser detection by user agent from OVV singleton to a helper class. For backwards compatibility to older versions of OVVAsset, OVV singleton will retain its browser properties, using an instance of the helper class to retrieve their values.
An additional helper class will determine if the browser supports the beacons method. After this fix and a previous FF fix, the only one that won't support is IE versions 10- or for Win under version 8.1 and other OS's.