### PR TITLE
Escaping injected script tag URI with JSON.stringify

### DIFF
--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -536,7 +536,7 @@ package org.openvv {
 				var injectTag:String =
 					'function () {' +
 					'var tag = document.createElement("script");' +
-					'tag.src = "' + tagUrl + '";' +
+					'tag.src = ' + JSON.stringify(tagUrl) + ';' +
 					'tag.type="text/javascript";' +
 					'document.getElementsByTagName("body")[0].appendChild(tag); }';
 				ExternalInterface.call( injectTag );

--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -536,7 +536,7 @@ package org.openvv {
 				var injectTag:String =
 					'function () {' +
 					'var tag = document.createElement("script");' +
-					'tag.src = ' + JSON.stringify(tagUrl) + ';' +
+					'tag.src = "' + tagUrl.replace(/"/g, '%22') + '";' +
 					'tag.type="text/javascript";' +
 					'document.getElementsByTagName("body")[0].appendChild(tag); }';
 				ExternalInterface.call( injectTag );


### PR DESCRIPTION
Passing the parameter to `addJavaScriptResourceOnEvent` straight to the document seems like a huge security risk. Let's at least let `JSON.stringify` turn it into a string.