### PR TITLE
Changed adVolume parent to _vpaidEventsDispatcher

### DIFF
--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -325,8 +325,8 @@ package org.openvv {
             if (results && !!results.error)
                 raiseError(results);
 
-            if (_ad != null && _ad.hasOwnProperty('adVolume')) {
-                results.volume = _ad['adVolume'];
+            if (_vpaidEventsDispatcher != null && _vpaidEventsDispatcher.hasOwnProperty('adVolume')) {
+                results.volume = _vpaidEventsDispatcher['adVolume'];
             }
 
             var displayState:String = getDisplayState(results);


### PR DESCRIPTION
Since the object returned by the getVPAID() call is not always reference to the ad, the _ad property is meant to be a reference to the ad's top DisplayObject which can be used to determine if the ad is running as full-screen.  The adVolume property is a child of the VPAID object, not (necessarily) the ad object.