### PR TITLE
Checking if interval timer exists before stopping it

### DIFF
--- a/src/org/openvv/OVVAsset.as
+++ b/src/org/openvv/OVVAsset.as
@@ -586,9 +586,11 @@ package org.openvv {
 			switch(event.type){
 				case VPAIDEvent.AdVideoComplete:
 					// stop time on ad completion
-					_intervalTimer.stop();
-					_intervalTimer.removeEventListener(TimerEvent.TIMER, onIntervalCheck);
-					_intervalTimer = null;
+					if (_intervalTimer) {
+						_intervalTimer.stop();
+						_intervalTimer.removeEventListener(TimerEvent.TIMER, onIntervalCheck);
+						_intervalTimer = null;
+					}
 					break;
 				case VPAIDEvent.AdImpression:
 					adStarted = true;


### PR DESCRIPTION
I got an exception on AdVideoComplete and was able to fix it with this safety check. Still trying to figure out exactly why `_intervalTimer` was null at that point, but it seems like a sane fix anyway.